### PR TITLE
Updated GitHub workflows

### DIFF
--- a/.github/workflows/canary_feature_deployment.yml
+++ b/.github/workflows/canary_feature_deployment.yml
@@ -103,11 +103,22 @@ jobs:
         cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
         cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true
         
-    # Creates a Git tag for this feature branch with a matching version format
-    - name: Create Git tag for feature branch
+    # Sets up Git identity for automated commits
+    - name: Configure Git
       run: |
         git config user.name "${{ env.GIT_USER_NAME }}"
         git config user.email "${{ env.GIT_USER_EMAIL }}"
+        git remote set-url origin git@github.com:${{ github.repository }}.git
+
+    # Sets up SSH for pushing changes to the repository to bypass branch protection rules
+    - name: Setup SSH for pushing
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.DEPLOY_KEY_PRIVATE }}
+
+    # Creates a Git tag for this feature branch with a matching version format
+    - name: Create Git tag for feature branch
+      run: |
         echo "Creating tag: ${{ steps.version_tag.outputs.tag }}"
         git tag -a "${{ steps.version_tag.outputs.tag }}" -m "Canary feature deployment for ${{ steps.feature_tag_name.outputs.feature_tag }}"
         git push origin "${{ steps.version_tag.outputs.tag }}"

--- a/.github/workflows/canary_feature_deployment.yml
+++ b/.github/workflows/canary_feature_deployment.yml
@@ -1,7 +1,7 @@
 # This workflow builds and pushes a Docker image for a canary feature deployment.
-
 name: Canary Feature Deployment
 
+# Configures workflow to be manually triggered with optional experiment name input
 on:
   workflow_dispatch:
     inputs:
@@ -10,12 +10,16 @@ on:
         required: false
         type: string
 
+# Sets environment variables for Docker image naming and tagging
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
   CANARY_TAG: canary # The stable tag for your experimental deployment slot
+  GIT_USER_NAME: "github-actions[bot]"
+  GIT_USER_EMAIL: "github-actions[bot]@users.noreply.github.com"
 
+# Grants permissions needed for package registry operations
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -23,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Determines the feature tag name from input or branch name with sanitization
     - name: Determine Feature Tag Name
       id: feature_tag_name
       run: |
@@ -43,16 +48,28 @@ jobs:
         fi
         echo "feature_tag=${SANITIZED_NAME}" >> $GITHUB_OUTPUT
         echo "Determined feature tag: ${SANITIZED_NAME}"
+    
+    # Creates the version tag name to be used in multiple steps
+    - name: Set Version Tag
+      id: version_tag
+      run: |
+        VERSION_TAG="version.beta-${{ steps.feature_tag_name.outputs.feature_tag }}"
+        echo "tag=${VERSION_TAG}" >> $GITHUB_OUTPUT
+        echo "Created version tag: ${VERSION_TAG}"
 
+    # Checks out the repository code
     - name: Checkout Code
       uses: actions/checkout@v4
 
+    # Sets up QEMU for multi-architecture container builds
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
+    # Configures Docker Buildx for multi-platform image builds
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    # Creates metadata for Docker image including feature-specific tags
     - name: Generate image metadata (tags, labels)
       id: meta
       uses: docker/metadata-action@v5
@@ -64,6 +81,7 @@ jobs:
         flavor: |
           latest=false
 
+    # Authenticates with GitHub Container Registry
     - name: Log in to GHCR
       uses: docker/login-action@v3
       with:
@@ -71,6 +89,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    # Builds and pushes the feature-specific Docker image with canary tags
     - name: Build & push Docker image
       uses: docker/build-push-action@v5
       with:
@@ -79,12 +98,23 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        # TODO: get correct version to add to the build args
         build-args: |
-          NEXT_PUBLIC_APP_VERSION="version beta-${{ steps.feature_tag_name.outputs.feature_tag }}"
+          NEXT_PUBLIC_APP_VERSION="${{ steps.version_tag.outputs.tag }}"
         cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
         cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true
+        
+    # Creates a Git tag for this feature branch with a matching version format
+    - name: Create Git tag for feature branch
+      run: |
+        git config user.name "${{ env.GIT_USER_NAME }}"
+        git config user.email "${{ env.GIT_USER_EMAIL }}"
+        echo "Creating tag: ${{ steps.version_tag.outputs.tag }}"
+        git tag -a "${{ steps.version_tag.outputs.tag }}" -m "Canary feature deployment for ${{ steps.feature_tag_name.outputs.feature_tag }}"
+        git push origin "${{ steps.version_tag.outputs.tag }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    # Outputs information about the built and pushed images for reference
     - name: Output image tags
       run: |
         echo "Pushed image with tags: ${{ steps.meta.outputs.tags }}"
@@ -93,3 +123,4 @@ jobs:
         echo "Image for the canary deployment slot:       ${{ env.IMAGE_NAME }}:${{ env.CANARY_TAG }}"
         echo "-------------------------------------------------------------------------"
         echo "Update your Kubernetes experimental deployment to use: ${{ env.IMAGE_NAME }}:${{ env.CANARY_TAG }}"
+        echo "Version tag created: ${{ steps.version_tag.outputs.tag }}"

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,21 +1,29 @@
+# Workflow for continuous delivery processes on direct commits to main branch
 name: Delivery
 
+# Triggers workflow on pushes to the main branch only, excluding tag pushes
 on:
   push:
     branches: [main]
+    tags-ignore: ['**']  # Ignores all tag pushes
 
+# Grants workflow permission to write to repository contents
 permissions:
   contents: write
 
 jobs:
   update-tag:
+    # This job will only run if the push was NOT made by the 'github-actions[bot]'. This actor is used to push changes in other workflows
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
 
     steps:
+    # Checks out the repository code with full history
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
+    # Creates a new pre-release tag with incremented version
     - name: Create new pre-release tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,8 @@
+# This workflow handles the stable release cycle process, including version bumping, GitHub releases,
+# Docker image building/publishing, and maintaining the development versioning between releases.
 name: Deployment
 
+# Defines the workflow to be manually triggered with options to specify the version bump level
 on:
   workflow_dispatch:
     inputs:
@@ -19,6 +22,8 @@ permissions:
   
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+  GIT_USER_NAME: "github-actions[bot]"
+  GIT_USER_EMAIL: "github-actions[bot]@users.noreply.github.com"
 
 jobs:
 
@@ -26,10 +31,24 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+    # Checks out the repository code to the runner
     - uses: actions/checkout@v4  
       with:
         fetch-depth: 0
 
+    # Sets up Git identity for automated commits
+    - name: Configure Git
+      run: |
+        git config user.name "${{ env.GIT_USER_NAME }}"
+        git config user.email "${{ env.GIT_USER_EMAIL }}"
+    
+    # Creates an empty commit to mark the stable release
+    - name: Create stable release commit
+      run: |
+        git commit --allow-empty -m "Stable release commit triggered by GitHub deployment action"
+        git push
+    
+    # Increments the version tag based on bump level (patch, minor, major)
     - name: Bump stable version
       id: bump_stable_tag
       uses: mathieudutour/github-tag-action@v6.2
@@ -39,14 +58,23 @@ jobs:
         default_bump: ${{ github.event.inputs.bump_level }}  
         tag_prefix: v
     
-    # Enables the runner to emulate different architectures
+    # Creates a GitHub release with the new version tag and changelog
+    - name: Create a GitHub release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ steps.bump_stable_tag.outputs.new_tag }}
+        name: Release ${{ steps.bump_stable_tag.outputs.new_tag }}
+        body: ${{ steps.bump_stable_tag.outputs.changelog }}    
+
+    # Sets up QEMU for multi-architecture container builds
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
-    # Creates a builder instance capable of multi-platform builds
+    # Configures Docker Buildx for multi-platform image builds
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    # Creates metadata for Docker image including tags and labels
     - name: Generate image metadata (tags, labels)
       id: meta
       uses: docker/metadata-action@v5
@@ -57,6 +85,7 @@ jobs:
           type=raw,value=latest
           type=raw,value=${{ steps.bump_stable_tag.outputs.new_tag }}
 
+    # Authenticates with GitHub Container Registry
     - name: Log in to GHCR
       uses: docker/login-action@v3
       with:
@@ -64,6 +93,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    # Builds and pushes the Docker image to GHCR with appropriate tags
     - name: Build & push docker image
       uses: docker/build-push-action@v5
       with:
@@ -76,6 +106,13 @@ jobs:
         cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
         cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true
 
+    # Creates an empty commit to start the next development cycle
+    - name: Create next pre-release commit
+      run: |
+        git commit --allow-empty -m "New pre-release commit triggered by GitHub deployment action"
+        git push
+
+    # Bumps version to next pre-release for continued development
     - name: Bump patch and add pre tag
       id: bump_patch
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -41,6 +41,13 @@ jobs:
       run: |
         git config user.name "${{ env.GIT_USER_NAME }}"
         git config user.email "${{ env.GIT_USER_EMAIL }}"
+        git remote set-url origin git@github.com:${{ github.repository }}.git
+
+    # Sets up SSH for pushing changes to the repository to bypass branch protection rules
+    - name: Setup SSH for pushing
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.DEPLOY_KEY_PRIVATE }}
     
     # Creates an empty commit to mark the stable release
     - name: Create stable release commit

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,7 @@
+# This workflow runs integration tests on pull requests to ensure code quality before merging
 name: Integration
 
+# Triggers workflow on pull requests to the main branch, excluding documentation changes
 on:
   pull_request:
     branches: [main] 
@@ -10,19 +12,23 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      # Checks out the repository code for testing
       - name: Checkout source
         uses: actions/checkout@v4
 
+      # Sets up Node.js environment with caching for faster dependency installation
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 23
           cache: npm
 
+      # Installs project dependencies using clean install
       - name: Install dependencies
         run: |
           npm ci
 
+      # Runs linting and code formatting checks
       - name: Lint and format check
         run: |
           npm run lint
@@ -35,6 +41,7 @@ jobs:
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
 
+      # Validates that the Docker image builds successfully for multiple architectures without pushing
       - name: Build docker image for multi-architecture
         id: docker_build_validate
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Closes #19 

- The release workflow now creates a stable commit, creates a GitHub release using new stable tag, releases the new stable version to the GitHub container registry, creates an new pre-release commit, pushes new pre-release tag.
- Canary deployments now create a tag as well that corresponds with the version of the released image